### PR TITLE
fix(trainer): create trainer row if missing on POST /api/auth/trainer

### DIFF
--- a/data/trainers.ts
+++ b/data/trainers.ts
@@ -26,6 +26,15 @@ function getTrainerWithUserSelect() {
   };
 }
 
+export async function createTrainer(userId: number): Promise<SelectTrainer | null> {
+  const [result] = await db
+    .insert(trainers)
+    .values({ user_id: userId })
+    .returning();
+
+  return result ?? null;
+}
+
 export async function updateTrainer(trainerId: number, updates: UpdateTrainer): Promise<SelectTrainer | null> {
   const [result] = await db
     .update(trainers)

--- a/service/auth/trainers.ts
+++ b/service/auth/trainers.ts
@@ -1,4 +1,4 @@
-import { getTrainerByUserId, updateTrainer } from "@/data/trainers";
+import { createTrainer, getTrainerByUserId, updateTrainer } from "@/data/trainers";
 import { TrainerNotFoundError } from "../errors";
 import type { TrainerInfo, UpdateTrainer } from "@/types/trainers";
 
@@ -15,11 +15,17 @@ export async function createOrUpdateTrainer(
   userId: number,
   trainerData: UpdateTrainer
 ): Promise<TrainerInfo> {
+  let trainerId: number;
   const existingTrainer = await getTrainerByUserId(userId);
-  if (!existingTrainer)
-    throw new TrainerNotFoundError();
+  if (existingTrainer) {
+    trainerId = existingTrainer.id;
+  } else {
+    const created = await createTrainer(userId);
+    if (!created) throw new TrainerNotFoundError();
+    trainerId = created.id;
+  }
 
-  const updatedTrainer = await updateTrainer(existingTrainer.id, trainerData);
+  const updatedTrainer = await updateTrainer(trainerId, trainerData);
   if (!updatedTrainer)
     throw new TrainerNotFoundError();
 


### PR DESCRIPTION
createOrUpdateTrainer was throwing TrainerNotFoundError (→ 404) for users without an existing trainer row. It now inserts one before applying the update.