### PR TITLE
refactor(email): move templates to files, remove env var defaults

### DIFF
--- a/service/auth/email.ts
+++ b/service/auth/email.ts
@@ -1,167 +1,46 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
 import { Resend } from 'resend';
 import { ServerError } from '../errors';
 
-/**
- * sendVerificationEmail({ email, name, token })
- *  returns: message_id
- *  errors: ServerError
- * 
- * @param email - The email address
- * @param name - The name of the user
- * @param token - The token to send
- * @throws ServerError - If Resend fails.
- */
-export async function sendVerificationEmail(email: string, name: string, token: string) {
-  const resend = new Resend(process.env.RESEND_API_KEY);
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  const verificationUrl = `${appUrl}/verify-email?token=${token}`;
+function getEnv(key: string): string {
+  const value = process.env[key];
+  if (!value) throw new ServerError(`Missing required environment variable: ${key}`);
+  return value;
+}
 
-  const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
-  const fromName = process.env.RESEND_FROM_NAME || 'BuscarEntrenador.com';
+async function loadTemplate(name: string, vars: Record<string, string>): Promise<{ html: string; text: string }> {
+  const dir = path.join(process.cwd(), 'service/templates');
+  const [html, text] = await Promise.all([
+    readFile(path.join(dir, `${name}.html`), 'utf-8'),
+    readFile(path.join(dir, `${name}.txt`), 'utf-8'),
+  ]);
 
-  const htmlContent = `
-    <!DOCTYPE html>
-    <html lang="es">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Verificá tu correo electrónico</title>
-    </head>
-    <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-      <div style="background-color: #f4f4f4; padding: 20px; border-radius: 10px;">
-        <h1 style="color: #4f46e5; margin-bottom: 20px;">¡Bienvenido a BuscarEntrenador.com!</h1>
-        
-        <p>Hola ${name},</p>
-        
-        <p>Gracias por registrarte en BuscarEntrenador.com. Para completar tu registro, necesitamos que verifiques tu correo electrónico.</p>
-        
-        <div style="text-align: center; margin: 30px 0;">
-          <a href="${verificationUrl}" 
-             style="background-color: #4f46e5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
-            Verificar mi correo
-          </a>
-        </div>
-        
-        <p>Si el botón no funciona, copiá y pegá el enlace de arriba en tu navegador:</p>
-        
-        <p style="color: #666; font-size: 14px; margin-top: 30px;">
-          Este enlace expirará en 24 horas. Si no solicitaste esta verificación, podés ignorar este correo.
-        </p>
-        
-        <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
-        
-        <p style="color: #999; font-size: 12px; text-align: center;">
-          BuscarEntrenador.com - Tu plataforma para encontrar entrenadores matematicos
-        </p>
-      </div>
-    </body>
-    </html>
-  `;
+  const interpolate = (s: string) =>
+    s.replace(/\{\{(\w+)\}\}/g, (_, key) => vars[key] ?? '');
 
-  const textContent = `
-Hola ${name},
+  return { html: interpolate(html), text: interpolate(text) };
+}
 
-Gracias por registrarte en BuscarEntrenador.com. Para completar tu registro, necesitamos que verifiques tu correo electrónico.
+async function sendEmail(to: string, subject: string, templateName: string, vars: Record<string, string>) {
+  const resend = new Resend(getEnv('RESEND_API_KEY'));
+  const from = `${getEnv('RESEND_FROM_NAME')} <${getEnv('RESEND_FROM_EMAIL')}>`;
+  const { html, text } = await loadTemplate(templateName, vars);
 
-Hacé clic en el siguiente enlace para verificar tu correo:
-${verificationUrl}
+  const { error } = await resend.emails.send({ from, to, subject, html, text });
+  if (error) throw new ServerError(`Failed to send email: ${subject}`);
+}
 
-Este enlace expirará en 24 horas. Si no solicitaste esta verificación, podés ignorar este correo.
-
-BuscarEntrenador.com - Tu plataforma para encontrar entrenadores matematicos
-  `;
-
-  const { error } = await resend.emails.send({
-    from: `${fromName} <${fromEmail}>`,
-    to: email,
-    subject: 'Verificá tu correo electrónico - BuscarEntrenador.com',
-    text: textContent,
-    html: htmlContent,
-  });
-
-  if (error) {
-    throw new ServerError('Failed to send verification email');
-  }
-
-  return;
+export async function sendVerificationEmail(email: string, name: string, token: string): Promise<void> {
+  const url = `${getEnv('NEXT_PUBLIC_APP_URL')}/verify-email?token=${token}`;
+  await sendEmail(email, 'Verificá tu correo electrónico - BuscarEntrenador.com', 'verify-email', { name, url });
 }
 
 export async function sendPasswordResetEmail({ email, name, token }: {
   email: string;
   name: string;
   token: string;
-}) {
-  const resend = new Resend(process.env.RESEND_API_KEY);
-  const appUrl = process.env.NEXT_PUBLIC_APP_URL;
-  const resetUrl = `${appUrl}/reset-password?token=${token}`;
-
-  const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
-  const fromName = process.env.RESEND_FROM_NAME || 'BuscarEntrenador.com';
-
-  const htmlContent = `
-    <!DOCTYPE html>
-    <html lang="es">
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Resetear tu contraseña</title>
-    </head>
-    <body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-      <div style="background-color: #f4f4f4; padding: 20px; border-radius: 10px;">
-        <h1 style="color: #4f46e5; margin-bottom: 20px;">Resetear tu contraseña</h1>
-        
-        <p>Hola ${name},</p>
-        
-        <p>Recibimos una solicitud para resetear la contraseña de tu cuenta en BuscarEntrenador.com.</p>
-        
-        <div style="text-align: center; margin: 30px 0;">
-          <a href="${resetUrl}" 
-             style="background-color: #4f46e5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
-            Resetear mi contraseña
-          </a>
-        </div>
-        
-        <p>Si el botón no funciona, copiá y pegá el enlace de arriba en tu navegador:</p>
-        <p style="word-break: break-all; color: #4f46e5;">${resetUrl}</p>
-        
-        <p style="color: #666; font-size: 14px; margin-top: 30px;">
-          Este enlace expirará en 1 hora por motivos de seguridad. Si no solicitaste resetear tu contraseña, podés ignorar este correo de forma segura.
-        </p>
-        
-        <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
-        
-        <p style="color: #999; font-size: 12px; text-align: center;">
-          BuscarEntrenador.com - Tu plataforma para encontrar entrenadores matematicos
-        </p>
-      </div>
-    </body>
-    </html>
-  `;
-
-  const textContent = `
-Hola ${name},
-
-Recibimos una solicitud para resetear la contraseña de tu cuenta en BuscarEntrenador.com.
-
-Hacé clic en el siguiente enlace para resetear tu contraseña:
-${resetUrl}
-
-Este enlace expirará en 1 hora por motivos de seguridad. Si no solicitaste resetear tu contraseña, podés ignorar este correo de forma segura.
-
-BuscarEntrenador.com - Tu plataforma para encontrar entrenadores matematicos
-  `;
-
-  const { error } = await resend.emails.send({
-    from: `${fromName} <${fromEmail}>`,
-    to: email,
-    subject: 'Resetear tu contraseña - BuscarEntrenador.com',
-    text: textContent,
-    html: htmlContent,
-  });
-
-  if (error) {
-    throw new ServerError('Failed to send password reset email');
-  }
-
-  return;
+}): Promise<void> {
+  const url = `${getEnv('NEXT_PUBLIC_APP_URL')}/reset-password?token=${token}`;
+  await sendEmail(email, 'Resetear tu contraseña - BuscarEntrenador.com', 'reset-password', { name, url });
 }

--- a/service/templates/reset-password.html
+++ b/service/templates/reset-password.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Resetear tu contraseña</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background-color: #f4f4f4; padding: 20px; border-radius: 10px;">
+    <h1 style="color: #4f46e5; margin-bottom: 20px;">Resetear tu contraseña</h1>
+
+    <p>Hola {{name}},</p>
+
+    <p>Recibimos una solicitud para resetear la contraseña de tu cuenta en BuscarEntrenador.com.</p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="{{url}}"
+         style="background-color: #4f46e5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+        Resetear mi contraseña
+      </a>
+    </div>
+
+    <p>Si el botón no funciona, copiá y pegá el siguiente enlace en tu navegador:</p>
+    <p style="word-break: break-all; color: #4f46e5;">{{url}}</p>
+
+    <p style="color: #666; font-size: 14px; margin-top: 30px;">
+      Este enlace expirará en 1 hora por motivos de seguridad. Si no solicitaste resetear tu contraseña, podés ignorar este correo de forma segura.
+    </p>
+
+    <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
+
+    <p style="color: #999; font-size: 12px; text-align: center;">
+      BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales
+    </p>
+  </div>
+</body>
+</html>

--- a/service/templates/reset-password.txt
+++ b/service/templates/reset-password.txt
@@ -1,0 +1,10 @@
+Hola {{name}},
+
+Recibimos una solicitud para resetear la contraseña de tu cuenta en BuscarEntrenador.com.
+
+Hacé clic en el siguiente enlace para resetear tu contraseña:
+{{url}}
+
+Este enlace expirará en 1 hora por motivos de seguridad. Si no solicitaste resetear tu contraseña, podés ignorar este correo de forma segura.
+
+BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales

--- a/service/templates/verify-email.html
+++ b/service/templates/verify-email.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verificá tu correo electrónico</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background-color: #f4f4f4; padding: 20px; border-radius: 10px;">
+    <h1 style="color: #4f46e5; margin-bottom: 20px;">¡Bienvenido a BuscarEntrenador.com!</h1>
+
+    <p>Hola {{name}},</p>
+
+    <p>Gracias por registrarte en BuscarEntrenador.com. Para completar tu registro, necesitamos que verifiques tu correo electrónico.</p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="{{url}}"
+         style="background-color: #4f46e5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+        Verificar mi correo
+      </a>
+    </div>
+
+    <p>Si el botón no funciona, copiá y pegá el siguiente enlace en tu navegador:</p>
+    <p style="word-break: break-all; color: #4f46e5;">{{url}}</p>
+
+    <p style="color: #666; font-size: 14px; margin-top: 30px;">
+      Este enlace expirará en 24 horas. Si no solicitaste esta verificación, podés ignorar este correo.
+    </p>
+
+    <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
+
+    <p style="color: #999; font-size: 12px; text-align: center;">
+      BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales
+    </p>
+  </div>
+</body>
+</html>

--- a/service/templates/verify-email.txt
+++ b/service/templates/verify-email.txt
@@ -1,0 +1,10 @@
+Hola {{name}},
+
+Gracias por registrarte en BuscarEntrenador.com. Para completar tu registro, necesitamos que verifiques tu correo electrónico.
+
+Hacé clic en el siguiente enlace para verificar tu correo:
+{{url}}
+
+Este enlace expirará en 24 horas. Si no solicitaste esta verificación, podés ignorar este correo.
+
+BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales


### PR DESCRIPTION
HTML and plain-text email templates extracted to service/templates/. Uses {{name}} and {{url}} placeholders interpolated at send time. Shared sendEmail helper eliminates duplicated Resend boilerplate. getEnv() throws clearly on missing env vars instead of falling back to dev defaults.