### PR TITLE
refactor(errors): give each error class its own HTTP semantics

### DIFF
--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resetPassword } from '@/service/auth/password_reset';
-import { InvalidResetTokenError, ResetTokenExpiredError } from '@/service/errors';
+import { handleServiceError } from '@/app/api/helper';
 
 export async function POST(request: NextRequest) {
   try {
@@ -8,54 +8,17 @@ export async function POST(request: NextRequest) {
     const { token, password } = body;
 
     if (!token) {
-      return NextResponse.json(
-        { error: 'Token de reseteo es requerido' },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: 'Token de reseteo es requerido' }, { status: 400 });
     }
 
-    if (!password) {
-      return NextResponse.json(
-        { error: 'La nueva contraseña es requerida' },
-        { status: 400 }
-      );
+    if (!password || password.length < 8) {
+      return NextResponse.json({ error: 'La contraseña debe tener al menos 8 caracteres' }, { status: 400 });
     }
 
-    // Validate password strength (minimum 8 characters)
-    if (password.length < 8) {
-      return NextResponse.json(
-        { error: 'La contraseña debe tener al menos 8 caracteres' },
-        { status: 400 }
-      );
-    }
-
-    // Reset the password
     await resetPassword(token, password);
 
-    return NextResponse.json(
-      { message: 'Contraseña actualizada exitosamente' },
-      { status: 200 }
-    );
+    return NextResponse.json({ message: 'Contraseña actualizada exitosamente' }, { status: 200 });
   } catch (error) {
-    console.error('Reset password error:', error);
-
-    if (error instanceof InvalidResetTokenError) {
-      return NextResponse.json(
-        { error: 'Token de reseteo inválido o ya utilizado' },
-        { status: 400 }
-      );
-    }
-
-    if (error instanceof ResetTokenExpiredError) {
-      return NextResponse.json(
-        { error: 'El token de reseteo ha expirado. Por favor, solicitá uno nuevo.' },
-        { status: 400 }
-      );
-    }
-
-    return NextResponse.json(
-      { error: 'Ocurrió un error al resetear tu contraseña. Por favor, intentá de nuevo.' },
-      { status: 500 }
-    );
+    return handleServiceError(error);
   }
 }

--- a/app/api/helper.ts
+++ b/app/api/helper.ts
@@ -1,124 +1,16 @@
 import { NextResponse } from "next/server";
-import {
-  UserNotFoundError,
-  InvalidCredentialsError,
-  EmailNotVerifiedError,
-  AlreadyVerifiedError,
-  InvalidTokenError,
-  TokenExpiredError,
-  TrainerNotFoundError,
-  ServerError,
-  JsonError,
-  UnauthorizedError,
-  EmailAlreadyInUseError,
-  EmailRegisteredWithGoogleError,
-  EmailRegisteredWithCredentialsError
-} from "@/service/errors";
+import { AppError } from "@/service/errors";
 import { ZodError } from "zod";
 
 export function handleServiceError(error: unknown): NextResponse {
-  
-  if (error instanceof JsonError) {
-    return NextResponse.json(
-      { error: "Cuerpo de solicitud inválido" },
-      { status: 400 }
-    );
-  }
-
   if (error instanceof ZodError) {
-    return NextResponse.json(
-      { error: error.issues[0]?.message },
-      { status: 400 }
-    );
+    return NextResponse.json({ error: error.issues[0]?.message }, { status: 400 });
   }
 
-  if (error instanceof UnauthorizedError) {
-    return NextResponse.json(
-      { error: "No autorizado. Debes iniciar sesión." },
-      { status: 401 }
-    );
+  if (error instanceof AppError) {
+    return NextResponse.json({ error: error.clientMessage }, { status: error.statusCode });
   }
 
-  if (error instanceof UserNotFoundError) {
-    return NextResponse.json(
-      { error: "Usuario no encontrado" },
-      { status: 404 }
-    );
-  }
-  
-  if (error instanceof InvalidCredentialsError) {
-    return NextResponse.json(
-      { error: "Correo electrónico o contraseña incorrectos" },
-      { status: 401 }
-    );
-  }
-  
-  if (error instanceof EmailNotVerifiedError) {
-    return NextResponse.json(
-      { error: "Tu correo electrónico no está verificado" },
-      { status: 403 }
-    );
-  }
-  
-  if (error instanceof AlreadyVerifiedError) {
-    return NextResponse.json(
-      { error: "El correo ya está verificado" },
-      { status: 400 }
-    );
-  }
-
-  if (error instanceof EmailAlreadyInUseError) {
-    return NextResponse.json(
-      { error: "El correo electrónico ya está en uso" },
-      { status: 400 }
-    );
-  }
-
-  if (error instanceof EmailRegisteredWithGoogleError) {
-    return NextResponse.json(
-      { error: "Esta cuenta está registrada con Google. Iniciá sesión con Google." },
-      { status: 409 }
-    );
-  }
-
-  if (error instanceof EmailRegisteredWithCredentialsError) {
-    return NextResponse.json(
-      { error: "Esta cuenta está registrada con email y contraseña. Iniciá sesión con tu contraseña." },
-      { status: 409 }
-    );
-  }
-  
-  if (error instanceof InvalidTokenError) {
-    return NextResponse.json(
-      { error: "Token inválido" },
-      { status: 400 }
-    );
-  }
-  
-  if (error instanceof TokenExpiredError) {
-    return NextResponse.json(
-      { error: "El token ha expirado" },
-      { status: 400 }
-    );
-  }
-  
-  if (error instanceof TrainerNotFoundError) {
-    return NextResponse.json(
-      { error: "No se encontró el perfil de entrenador" },
-      { status: 404 }
-    );
-  }
-  
-  if (error instanceof ServerError) {
-    return NextResponse.json(
-      { error: error.message || "Error interno del servidor" },
-      { status: 500 }
-    );
-  }
-  
   console.error("Unhandled error:", error);
-  return NextResponse.json(
-    { error: "Error interno del servidor" },
-    { status: 500 }
-  );
+  return NextResponse.json({ error: "Error interno del servidor" }, { status: 500 });
 }

--- a/service/errors.ts
+++ b/service/errors.ts
@@ -1,108 +1,101 @@
-/**
- * Custom error classes for authentication and user operations
- */
-
-export class JsonError extends Error {
-  constructor() { 
-    super("Invalid JSON");
-    this.name = "JsonError";
+export class AppError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly clientMessage: string
+  ) {
+    super(message);
+    this.name = new.target.name;
   }
 }
 
-export class UnauthorizedError extends Error {
-  constructor() { 
-    super("Unauthorized");
-    this.name = "UnauthorizedError";
-  }
-}
-
-export class UserNotFoundError extends Error {
-  constructor() { 
-    super("User not found");
-    this.name = "UserNotFoundError";
-  }
-}
-
-export class InvalidCredentialsError extends Error {
-  constructor() { 
-    super("Invalid credentials");
-    this.name = "InvalidCredentialsError";
-  }
-}
-
-export class EmailNotVerifiedError extends Error {
-  constructor() { 
-    super("Email not verified");
-    this.name = "EmailNotVerifiedError";
-  }
-}
-
-export class AlreadyVerifiedError extends Error {
-  constructor() { 
-    super("Email already verified");
-    this.name = "AlreadyVerifiedError";
-  }
-}
-
-export class InvalidTokenError extends Error {
-  constructor() { 
-    super("Invalid verification token");
-    this.name = "InvalidTokenError";
-  }
-}
-
-export class TokenExpiredError extends Error {
-  constructor() { 
-    super("Verification token expired");
-    this.name = "TokenExpiredError";
-  }
-}
-
-export class InvalidResetTokenError extends Error {
-  constructor() { 
-    super("Invalid password reset token");
-    this.name = "InvalidResetTokenError";
-  }
-}
-
-export class ResetTokenExpiredError extends Error {
-  constructor() { 
-    super("Password reset token expired");
-    this.name = "ResetTokenExpiredError";
-  }
-}
-
-export class EmailAlreadyInUseError extends Error {
+export class JsonError extends AppError {
   constructor() {
-    super("Email already in use");
-    this.name = "EmailAlreadyInUseError";
+    super("Invalid JSON", 400, "Cuerpo de solicitud inválido");
   }
 }
 
-export class EmailRegisteredWithGoogleError extends Error {
+export class UnauthorizedError extends AppError {
   constructor() {
-    super("Email registered with Google");
-    this.name = "EmailRegisteredWithGoogleError";
+    super("Unauthorized", 401, "No autorizado. Debes iniciar sesión.");
   }
 }
 
-export class EmailRegisteredWithCredentialsError extends Error {
+export class UserNotFoundError extends AppError {
   constructor() {
-    super("Email registered with credentials");
-    this.name = "EmailRegisteredWithCredentialsError";
+    super("User not found", 404, "Usuario no encontrado");
   }
 }
 
-export class TrainerNotFoundError extends Error {
-  constructor() { 
-    super("Trainer not found");
-    this.name = "TrainerNotFoundError";
+export class InvalidCredentialsError extends AppError {
+  constructor() {
+    super("Invalid credentials", 401, "Correo electrónico o contraseña incorrectos");
   }
 }
 
-export class ServerError extends Error {
-  constructor(message?: string) { 
-    super(message || "Server error");
-    this.name = "ServerError";
+export class EmailNotVerifiedError extends AppError {
+  constructor() {
+    super("Email not verified", 403, "Tu correo electrónico no está verificado");
+  }
+}
+
+export class AlreadyVerifiedError extends AppError {
+  constructor() {
+    super("Email already verified", 400, "El correo ya está verificado");
+  }
+}
+
+export class InvalidTokenError extends AppError {
+  constructor() {
+    super("Invalid verification token", 400, "Token inválido");
+  }
+}
+
+export class TokenExpiredError extends AppError {
+  constructor() {
+    super("Verification token expired", 400, "El token ha expirado");
+  }
+}
+
+export class InvalidResetTokenError extends AppError {
+  constructor() {
+    super("Invalid password reset token", 400, "Token de reseteo inválido o ya utilizado");
+  }
+}
+
+export class ResetTokenExpiredError extends AppError {
+  constructor() {
+    super("Password reset token expired", 400, "El token de reseteo ha expirado. Por favor, solicitá uno nuevo.");
+  }
+}
+
+export class EmailAlreadyInUseError extends AppError {
+  constructor() {
+    super("Email already in use", 400, "El correo electrónico ya está en uso");
+  }
+}
+
+export class EmailRegisteredWithGoogleError extends AppError {
+  constructor() {
+    super("Email registered with Google", 409, "Esta cuenta está registrada con Google. Iniciá sesión con Google.");
+  }
+}
+
+export class EmailRegisteredWithCredentialsError extends AppError {
+  constructor() {
+    super("Email registered with credentials", 409, "Esta cuenta está registrada con email y contraseña. Iniciá sesión con tu contraseña.");
+  }
+}
+
+export class TrainerNotFoundError extends AppError {
+  constructor() {
+    super("Trainer not found", 404, "No se encontró el perfil de entrenador");
+  }
+}
+
+export class ServerError extends AppError {
+  constructor(message?: string) {
+    const msg = message || "Server error";
+    super(msg, 500, msg);
   }
 }


### PR DESCRIPTION
Each AppError subclass now carries statusCode and clientMessage, so handleServiceError becomes a generic 3-case handler instead of a 100-line instanceof chain. Also absorbs the local error handling in reset-password route, which had been bypassing the central helper.