### PR TITLE
refactor(auth): extract Google sign-in logic from NextAuth config

### DIFF
--- a/service/auth/next-auth.config.ts
+++ b/service/auth/next-auth.config.ts
@@ -3,21 +3,7 @@ import type { NextAuthConfig } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import GoogleProvider from "next-auth/providers/google";
 import { verifyLogin } from "@/service/auth/login";
-import { getUserByEmail, createGoogleUser, getUserByGoogleId } from "@/data/users";
-
-function splitGoogleName(profile: { name?: string | null; given_name?: string; family_name?: string }) {
-  const given = profile.given_name?.trim();
-  const family = profile.family_name?.trim();
-  if (given && family) return { name: given, surname: family };
-
-  const fullName = profile.name?.trim() ?? '';
-  const parts = fullName.split(/\s+/).filter(Boolean);
-
-  return {
-    name: given || parts[0] || 'Usuario',
-    surname: family || parts.slice(1).join(' ') || '-',
-  };
-}
+import { handleGoogleSignIn } from "@/service/auth/signup";
 
 export const authConfig: NextAuthConfig = {
   providers: [
@@ -28,13 +14,10 @@ export const authConfig: NextAuthConfig = {
         password: { label: "Password", type: "password" }
       },
       async authorize(credentials) {
-        if (!credentials?.email || !credentials?.password) {
-          return null;
-        }
+        if (!credentials?.email || !credentials?.password) return null;
         try {
-          const user = await verifyLogin(credentials.email as string, credentials.password as string);
-          return user;
-        } catch (error) {
+          return await verifyLogin(credentials.email as string, credentials.password as string);
+        } catch {
           return null;
         }
       }
@@ -51,44 +34,16 @@ export const authConfig: NextAuthConfig = {
       const googleId = account.providerAccountId;
       if (!googleId) return '/login?error=google_signup_failed';
 
-      const existingByGoogleId = await getUserByGoogleId(googleId);
-      if (existingByGoogleId) {
-        user.id = existingByGoogleId.id;
-        user.email = existingByGoogleId.email;
-        user.name = existingByGoogleId.name;
-        user.surname = existingByGoogleId.surname;
-        return true;
-      }
-
       const email = user?.email ?? profile?.email;
       if (!email) return '/login?error=google_no_email';
-      const { name, surname } = splitGoogleName(profile ?? {});
 
-      const existingByEmail = await getUserByEmail(email);
+      const result = await handleGoogleSignIn(googleId, email, profile ?? {});
+      if (typeof result === 'string') return result;
 
-      if (existingByEmail) {
-        if (existingByEmail.auth_provider !== 'google') {
-          return '/login?error=email_in_use_credentials';
-        }
-        user.id = existingByEmail.id;
-        user.email = existingByEmail.email;
-        user.name = existingByEmail.name;
-        user.surname = existingByEmail.surname;
-        return true;
-      }
-
-      const created = await createGoogleUser({
-        email,
-        name: user.name ?? name,
-        surname: user.surname ?? surname,
-        google_id: googleId,
-      });
-      if (!created) return '/login?error=google_signup_failed';
-
-      user.id = created.id;
-      user.email = created.email;
-      user.name = created.name;
-      user.surname = created.surname;
+      user.id = result.id;
+      user.email = result.email;
+      user.name = result.name;
+      user.surname = result.surname;
       return true;
     },
     async jwt({ token, user, trigger, session }: any) {

--- a/service/auth/signup.ts
+++ b/service/auth/signup.ts
@@ -1,31 +1,13 @@
 import { sendVerificationEmail } from "@/service/auth/email";
-import { createUser, getUserByEmail } from "@/data/users";
+import { createUser, getUserByEmail, createGoogleUser, getUserByGoogleId } from "@/data/users";
 import { generateVerificationToken } from "@/service/auth/verification_tokens";
 import { hashPassword } from "@/service/crypto";
-import { UserInfo } from "@/types/users";
+import type { UserInfo, SelectUser } from "@/types/users";
 import {
   EmailAlreadyInUseError,
   EmailRegisteredWithGoogleError,
 } from "@/service/errors";
 
-/**
- * Full signup flow:
- *  Creates user with provided email, password, name and surname
- *  Generates a random verification token.
- *  Sends it to the provided email address.
- *
- * @param email
- * @param password
- * @param name
- * @param surname
- * @returns The registered user's id.
- * @throws EmailAlreadyInUseError - if the email is registered with credentials
- * @throws EmailRegisteredWithGoogleError - if the email is registered with Google
- *
- * Dev notes:
- * - generateVerificationToken could throw UserNotFound or AlreadyVerifiedError, but this is not expected unless createUser is not working properly.
- * - sendVerificationEmail could throw a ServerError if something is wrong with the email sender.
- */
 export async function signupUser(
     email: string,
     password: string,
@@ -50,4 +32,44 @@ export async function signupUser(
   await sendVerificationEmail(user.email, user.name, token);
 
   return user;
+}
+
+type GoogleProfile = { name?: string | null; given_name?: string; family_name?: string };
+
+export function splitGoogleName(profile: GoogleProfile): { name: string; surname: string } {
+  const given = profile.given_name?.trim();
+  const family = profile.family_name?.trim();
+  if (given && family) return { name: given, surname: family };
+
+  const fullName = profile.name?.trim() ?? '';
+  const parts = fullName.split(/\s+/).filter(Boolean);
+
+  return {
+    name: given || parts[0] || 'Usuario',
+    surname: family || parts.slice(1).join(' ') || '-',
+  };
+}
+
+export async function handleGoogleSignIn(
+  googleId: string,
+  email: string,
+  profile: GoogleProfile
+): Promise<SelectUser | string> {
+  const existingByGoogleId = await getUserByGoogleId(googleId);
+  if (existingByGoogleId) return existingByGoogleId;
+
+  const { name, surname } = splitGoogleName(profile);
+
+  const existingByEmail = await getUserByEmail(email);
+  if (existingByEmail) {
+    if (existingByEmail.auth_provider !== 'google') {
+      return '/login?error=email_in_use_credentials';
+    }
+    return existingByEmail;
+  }
+
+  const created = await createGoogleUser({ email, name, surname, google_id: googleId });
+  if (!created) return '/login?error=google_signup_failed';
+
+  return created;
 }


### PR DESCRIPTION
Moves handleGoogleSignIn and splitGoogleName into service/auth/signup.ts so the Google account-creation flow is testable without a full OAuth round-trip. The NextAuth signIn callback becomes pure wiring: it resolves preconditions (googleId, email) then delegates.