### PR TITLE
fix(security): token order, password complexity, headers, rate limiting

### DIFF
--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -2,11 +2,22 @@ import { NextRequest, NextResponse } from "next/server";
 import { generatePasswordResetToken } from "@/service/auth/password_reset";
 import { sendPasswordResetEmail } from "@/service/auth/email";
 import { getUserByEmail } from "@/data/users";
+import { isRateLimited, RATE_LIMIT_RESPONSE } from "@/service/ratelimit";
 
 const SUCCESS_MESSAGE =
   "Si existe una cuenta con ese correo, recibirás un enlace para resetear tu contraseña";
 
+// Minimum response time in ms — masks the timing difference between known and unknown emails.
+const MIN_RESPONSE_MS = 800;
+
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  if (isRateLimited(`forgot-password:${ip}`, 5, 60 * 60 * 1000)) {
+    return NextResponse.json(RATE_LIMIT_RESPONSE, { status: 429 });
+  }
+
+  const started = Date.now();
+
   try {
     const body = await request.json();
     const { email } = body;
@@ -20,26 +31,21 @@ export async function POST(request: NextRequest) {
 
     const user = await getUserByEmail(email);
 
-    // Don't reveal whether the email exists (security best practice)
-    if (!user) {
-      return NextResponse.json({ message: SUCCESS_MESSAGE }, { status: 200 });
+    if (user) {
+      const token = await generatePasswordResetToken(email);
+      await sendPasswordResetEmail({ email: user.email, name: user.name, token });
     }
 
-    const token = await generatePasswordResetToken(email);
-    await sendPasswordResetEmail({
-      email: user.email,
-      name: user.name,
-      token,
-    });
+    const elapsed = Date.now() - started;
+    if (elapsed < MIN_RESPONSE_MS) {
+      await new Promise(r => setTimeout(r, MIN_RESPONSE_MS - elapsed));
+    }
 
     return NextResponse.json({ message: SUCCESS_MESSAGE }, { status: 200 });
   } catch (error) {
     console.error("Forgot password error:", error);
     return NextResponse.json(
-      {
-        error:
-          "Ocurrió un error al procesar tu solicitud. Por favor, intentá de nuevo.",
-      },
+      { error: "Ocurrió un error al procesar tu solicitud. Por favor, intentá de nuevo." },
       { status: 500 },
     );
   }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -3,6 +3,7 @@ import { verifyLogin } from "@/service/auth/login";
 import { z } from "zod";
 import { handleServiceError } from "../../helper";
 import { JsonError } from "@/service/errors";
+import { isRateLimited, RATE_LIMIT_RESPONSE } from "@/service/ratelimit";
 
 const loginSchema = z.object({
   email: z.string().email("El correo electrónico no es válido"),
@@ -10,6 +11,11 @@ const loginSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  if (isRateLimited(`login:${ip}`, 10, 15 * 60 * 1000)) {
+    return NextResponse.json(RATE_LIMIT_RESPONSE, { status: 429 });
+  }
+
   try {
     const body = await request.json().catch(() => { throw new JsonError(); });
     const { email, password } = loginSchema.parse(body);

--- a/app/api/auth/reset-password/route.ts
+++ b/app/api/auth/reset-password/route.ts
@@ -1,8 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { resetPassword } from '@/service/auth/password_reset';
 import { handleServiceError } from '@/app/api/helper';
+import { isRateLimited, RATE_LIMIT_RESPONSE } from '@/service/ratelimit';
+
+const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
 
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  if (isRateLimited(`reset-password:${ip}`, 5, 15 * 60 * 1000)) {
+    return NextResponse.json(RATE_LIMIT_RESPONSE, { status: 429 });
+  }
+
   try {
     const body = await request.json();
     const { token, password } = body;
@@ -11,8 +19,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Token de reseteo es requerido' }, { status: 400 });
     }
 
-    if (!password || password.length < 8) {
-      return NextResponse.json({ error: 'La contraseña debe tener al menos 8 caracteres' }, { status: 400 });
+    if (!password || !passwordRegex.test(password)) {
+      return NextResponse.json(
+        { error: 'La contraseña debe tener al menos 8 caracteres, incluir mayúscula, minúscula y número' },
+        { status: 400 }
+      );
     }
 
     await resetPassword(token, password);

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { signupUser } from "@/service/auth/signup";
 import { handleServiceError } from "../../helper";
 import { JsonError } from "@/service/errors";
+import { isRateLimited, RATE_LIMIT_RESPONSE } from "@/service/ratelimit";
 
 const passwordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[A-Za-z\d]{8,}$/;
 const nameRegex = /^[a-zA-Z0-9áéíóúÁÉÍÓÚñÑüÜ\s]+$/;
@@ -30,6 +31,11 @@ const signupSchema = z.object({
 });
 
 export async function POST(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown';
+  if (isRateLimited(`signup:${ip}`, 5, 60 * 60 * 1000)) {
+    return NextResponse.json(RATE_LIMIT_RESPONSE, { status: 429 });
+  }
+
   try {
     const body = await request.json().catch(() => {
       throw new JsonError();

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,18 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          { key: 'X-Frame-Options', value: 'DENY' },
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+        ],
+      },
+    ];
+  },
+};
+
 export default nextConfig;

--- a/service/auth/password_reset.ts
+++ b/service/auth/password_reset.ts
@@ -56,10 +56,9 @@ export async function resetPassword(
   if (new Date() > new Date(tokenData.expires))
     throw new ResetTokenExpiredError();
 
-  // Hash the new password and update the user
+  // Delete the token before updating so a failed update cannot be retried with the same token.
+  await deletePasswordResetTokenByUser(tokenData.id);
+
   const newPasswordHash = await hashPassword(newPassword);
   await updateUser(tokenData.id, { password_hash: newPasswordHash });
-
-  // Delete the used token
-  await deletePasswordResetTokenByUser(tokenData.id);
 }

--- a/service/auth/verification_tokens.ts
+++ b/service/auth/verification_tokens.ts
@@ -48,8 +48,9 @@ export async function verifyUserEmail(token: string) {
   if (new Date() > new Date(tokenData.expires))
     throw new TokenExpiredError();
 
-  await updateUser(tokenData.user_id, { email_verified: true });
+  // Delete the token before marking verified so a failed update cannot be retried.
   await deleteVerificationTokenByUser(tokenData.user_id);
+  await updateUser(tokenData.user_id, { email_verified: true });
 }
 
 /**

--- a/service/ratelimit.ts
+++ b/service/ratelimit.ts
@@ -1,0 +1,16 @@
+// In-memory sliding window rate limiter.
+// NOTE: each serverless instance maintains its own window — for cross-instance
+// enforcement in production, back this with a distributed store (Vercel KV, Upstash).
+
+const windows = new Map<string, number[]>();
+
+export function isRateLimited(key: string, limit: number, windowMs: number): boolean {
+  const now = Date.now();
+  const timestamps = (windows.get(key) ?? []).filter(t => now - t < windowMs);
+  if (timestamps.length >= limit) return true;
+  timestamps.push(now);
+  windows.set(key, timestamps);
+  return false;
+}
+
+export const RATE_LIMIT_RESPONSE = { error: 'Demasiados intentos. Intentá de nuevo más tarde.' };


### PR DESCRIPTION
- Flip token deletion order in resetPassword and verifyUserEmail: token is now consumed before the DB write so a failed write cannot be retried with the same token.
- Apply the same password complexity regex (uppercase + lowercase + digit) to the reset-password endpoint that signup already enforced.
- Add security headers to next.config.mjs: X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy.
- Add in-memory sliding-window rate limiter (service/ratelimit.ts) and apply it to login (10/15min), signup (5/hr), forgot-password (5/hr), and reset-password (5/15min) per IP.
- Fix timing-based email enumeration in forgot-password: both code paths now wait a minimum of 800ms before responding.