### PR TITLE
fix(auth): rate-limit credentials login (H-2)

### DIFF
--- a/service/auth/next-auth.config.ts
+++ b/service/auth/next-auth.config.ts
@@ -7,6 +7,7 @@ import { db } from "@/db/index";
 import { users, accounts } from "@/db/schema";
 import { verifyLogin } from "@/service/auth/login";
 import { getUserByEmail } from "@/service/users";
+import { rateLimiter } from "@/service/rate_limiter";
 
 type NameParts = {
   name?: string | null;
@@ -37,8 +38,15 @@ export const authConfig: NextAuthConfig = {
         email: { label: "Email", type: "email" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, request) {
         if (!credentials?.email || !credentials?.password) return null;
+
+        // The limiter counts all attempts (not just failures), so keep limits
+        // loose enough that a legitimate user retrying doesn't lock themselves out.
+        const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+        if (await rateLimiter.check(`login:${ip}`, 10, 15 * 60 * 1000)) return null;
+        if (await rateLimiter.check(`login-email:${credentials.email}`, 10, 15 * 60 * 1000)) return null;
+
         try {
           return await verifyLogin(
             credentials.email as string,


### PR DESCRIPTION
## Summary
- Fixes **H-2** from `SECURITY_AUDIT.md`: since the custom `/api/auth/login` route was removed in #41, the NextAuth credentials callback (`/api/auth/callback/credentials`) had **no rate limiting at all** — the only throttle on password guessing was bcrypt cost.
- Adds throttling inside `authorize()` in `service/auth/next-auth.config.ts`: **10 attempts per IP** and **10 attempts per email** per 15-minute window, using the same `rateLimiter` + `x-forwarded-for` pattern as the other auth routes (signup, forgot-password, resend-verification).
- When limited, `authorize()` returns `null`, so the client sees the same generic credentials error — no account-state leak.

## Notes
- Limits count **all** attempts (the limiter has no failure-only mode), so they're deliberately loose enough that a legitimate user retrying across devices won't lock themselves out.
- This is only as strong as the limiter under it: the in-memory `MemoryRateLimiter` is per-lambda on Vercel (audit M-3) and `x-forwarded-for` is trusted (M-4). Swapping in a distributed limiter (Upstash / Vercel KV) is tracked separately.

## Test plan
- [ ] Wrong password 10× from one session → 11th attempt is rejected even with correct credentials until the window expires
- [ ] Successful login still works under normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)