### PR TITLE
fix(trainers): hidden profiles no longer reachable by ID (M-2)

### DIFF
--- a/service/trainers.ts
+++ b/service/trainers.ts
@@ -62,7 +62,7 @@ export async function getTrainerById(
     .select(publicTrainerSelect())
     .from(trainers)
     .innerJoin(users, eq(trainers.user_id, users.id))
-    .where(eq(trainers.id, id))
+    .where(and(eq(trainers.id, id), eq(trainers.is_visible, true)))
     .limit(1);
 
   return result ?? null;


### PR DESCRIPTION
## Summary
- Fixes **M-2** from `SECURITY_AUDIT.md`: a trainer who toggled their profile to hidden was removed from the `/entrenadores` listing, but their profile page stayed publicly reachable (and search-engine indexable) at `/entrenadores/[id]` — and IDs are sequential `serial`, so enumeration is trivial.
- `getTrainerById` now filters `is_visible = true`, so hidden profiles return a 404 exactly like nonexistent ones.

## Notes
- `getTrainerById` has a single caller (the public detail page), so no other flow changes behavior.
- The owner still sees and edits their own hidden profile via `/cuenta` and `/soy-entrenador`, which use `getTrainerByUserId`.
- `updateTrainerVisibility` stores `null` for hidden (not `false`); `eq(is_visible, true)` excludes both `null` and `false`, so both representations are handled.

## Test plan
- [ ] Hide a trainer profile from the dashboard → its `/entrenadores/[id]` URL returns 404
- [ ] The hidden trainer still sees their profile in `/cuenta`
- [ ] Re-enabling visibility makes the public page resolve again

🤖 Generated with [Claude Code](https://claude.com/claude-code)