### PR TITLE
fix(trainers): hide trainer emails from unauthenticated visitors (M-8)

### DIFF
--- a/app/entrenadores/[id]/page.tsx
+++ b/app/entrenadores/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import Info from "@/app/ui/entrenadores/info";
 import { getTrainerById } from "@/service/trainers";
+import { auth } from "@/service/auth/next-auth.config";
 import { notFound } from 'next/navigation';
 
 export default async function Page({ params }: {
@@ -13,6 +14,11 @@ export default async function Page({ params }: {
   let trainer = await getTrainerById(Number(id));
   if (!trainer) {
     notFound();
+  }
+
+  const session = await auth();
+  if (!session?.user) {
+    trainer = { ...trainer, email: null };
   }
 
   return (

--- a/app/entrenadores/page.tsx
+++ b/app/entrenadores/page.tsx
@@ -7,6 +7,7 @@ import CardGrid from '@/app/ui/entrenadores/card';
 import Pagination from '@/app/ui/entrenadores/pagination';
 import LocationFilter from '@/app/ui/entrenadores/loc/location_filter';
 import { getTrainersByFilters } from '@/service/trainers';
+import { auth } from '@/service/auth/next-auth.config';
 import { redirect } from 'next/navigation';
 
 export default async function Page({ searchParams }: {
@@ -35,6 +36,13 @@ export default async function Page({ searchParams }: {
     });
   } catch (error) {
     redirect('/login');
+  }
+
+  // Trainer cards are client components, so the whole object reaches the
+  // browser even if the email is never rendered — strip it for visitors.
+  const session = await auth();
+  if (!session?.user) {
+    trainers = trainers.map((trainer) => ({ ...trainer, email: null }));
   }
 
   return (

--- a/app/ui/entrenadores/info.tsx
+++ b/app/ui/entrenadores/info.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image'
+import Link from 'next/link'
 import type { PublicTrainerUser } from '@/types/trainers'
 
 export default function Info({ trainer, individualProfile }: {
@@ -46,9 +47,15 @@ export default function Info({ trainer, individualProfile }: {
                 <svg className='w-4 h-4' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
                   <path strokeLinecap='round' strokeLinejoin='round' strokeWidth={2} d='M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z' />
                 </svg>
-                <a href={`mailto:${trainer.email}`} className='text-indigo-600 hover:text-indigo-700 hover:underline'>
-                  {trainer.email}
-                </a>
+                {trainer.email ? (
+                  <a href={`mailto:${trainer.email}`} className='text-indigo-600 hover:text-indigo-700 hover:underline'>
+                    {trainer.email}
+                  </a>
+                ) : (
+                  <Link href='/login' className='text-indigo-600 hover:text-indigo-700 hover:underline'>
+                    Iniciá sesión para ver el correo
+                  </Link>
+                )}
               </div>
             )}
           </div>

--- a/types/trainers.ts
+++ b/types/trainers.ts
@@ -83,5 +83,6 @@ export type PublicTrainer = Pick<
   | "examenes_oma"
 >;
 
-// only visible information
-export type PublicTrainerUser = PublicTrainer & PublicUser;
+// only visible information; email is null when the viewer is not authenticated
+export type PublicTrainerUser = PublicTrainer &
+  Omit<PublicUser, "email"> & { email: string | null };


### PR DESCRIPTION
## Summary
- Fixes **M-8** from `SECURITY_AUDIT.md`: trainer login emails were exposed to unauthenticated visitors in two places:
  1. Rendered as a `mailto:` link on the public profile page `/entrenadores/[id]`.
  2. Serialized into the client payload of the `/entrenadores` listing — `CardGrid` is a client component, so every trainer object (email included) reached the browser even though cards never render it. Combined with sequential IDs, the full trainer email list was harvestable with a trivial crawl.
- Both pages now check `auth()` and null out `email` server-side before the data crosses to the client when there is no session.
- `PublicTrainerUser.email` becomes `string | null`, and the profile page shows an **"Iniciá sesión para ver el correo"** link to `/login` instead of the mailto.

## Notes
- Logged-in users see emails exactly as before.
- `/cuenta` and `/soy-entrenador` are unaffected (own-session data via `getTrainerByUserId`).
- Stripping happens at the page boundary rather than in the service so the service keeps returning full rows for authenticated use.

## Test plan
- [ ] Logged out: `/entrenadores/[id]` shows the login link, no email anywhere in the page source or RSC payload
- [ ] Logged out: `view-source`/payload of `/entrenadores` contains no `@` trainer emails
- [ ] Logged in: profile page shows the mailto link as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)