### PR TITLE
fix(security): make ServerError.clientMessage always generic (M-7)

### DIFF
--- a/service/errors.ts
+++ b/service/errors.ts
@@ -35,7 +35,6 @@ export class TrainerNotFoundError extends AppError {
 
 export class ServerError extends AppError {
   constructor(message?: string) {
-    const msg = message || "Server error";
-    super(msg, 500, msg);
+    super(message || "Server error", 500, "Error interno del servidor");
   }
 }


### PR DESCRIPTION
## Summary

- `ServerError` previously set `clientMessage` to the same string as the internal message, leaking details like env var names and email subjects to HTTP responses
- Now always returns `"Error interno del servidor"` to clients; detailed message is preserved internally for server-side logging

## Test plan

- [ ] Trigger a mailer failure (e.g. bad Resend key) and confirm the HTTP response body says `"Error interno del servidor"`, not the internal message

🤖 Generated with [Claude Code](https://claude.com/claude-code)