### PR TITLE
fix(security): add input length caps to trainer endpoint (M-6)

### DIFF
--- a/app/api/auth/trainer/route.ts
+++ b/app/api/auth/trainer/route.ts
@@ -9,11 +9,11 @@ import { JsonError, UnauthorizedError } from "@/service/errors";
 const trainerSchema = z.object({
   province: z.string().optional(),
   city: z.string().optional(),
-  description: z.string().optional(),
+  description: z.string().max(2000).optional(),
   places: z.array(z.boolean()).length(3).optional(),
   groups: z.array(z.boolean()).length(3).optional(),
   levels: z.array(z.boolean()).length(5).optional(),
-  certifications: z.array(z.string()).optional(),
+  certifications: z.array(z.string().max(200)).max(20).optional(),
   soy_exo: z.boolean().optional(),
   examenes_oma: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary

- `description`: capped at 2000 characters
- `certifications`: each item capped at 200 characters, array capped at 20 items

## Test plan

- [ ] POST to `/api/auth/trainer` with a description > 2000 chars — expect 400
- [ ] POST with > 20 certifications — expect 400
- [ ] POST with a certification item > 200 chars — expect 400
- [ ] Normal trainer update still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)