### PR TITLE
fix(security): add missing HTTP security headers (I-2)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,10 @@ const nextConfig = {
           { key: 'X-Frame-Options', value: 'DENY' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
           { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+          { key: 'Cross-Origin-Opener-Policy', value: 'same-origin' },
+          { key: 'Cross-Origin-Resource-Policy', value: 'same-site' },
+          { key: 'Content-Security-Policy-Report-Only', value: "default-src 'self'; script-src 'self' https://accounts.google.com; frame-src https://accounts.google.com; report-uri /api/csp-report" },
         ],
       },
     ];


### PR DESCRIPTION
## Summary

Adds four missing response headers to all routes:

- **HSTS** (`max-age=63072000; includeSubDomains; preload`) — enforces HTTPS on the custom domain
- **COOP** (`same-origin`) — blocks cross-origin window references
- **CORP** (`same-site`) — mitigates Spectre-class cross-origin leaks
- **CSP** (report-only) — flags violations without breaking anything; covers `self` + Google Sign-In origins. Upgrade to enforcing once violations are reviewed.

## Test plan

- [ ] Check response headers on any page — all four new headers should be present
- [ ] Google Sign-In still works (allowed in CSP `script-src`)
- [ ] No console CSP violations on normal page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)