### PR TITLE
fix(security): remove incorrect 'use server' from page files (I-3)

### DIFF
--- a/app/cuenta/page.tsx
+++ b/app/cuenta/page.tsx
@@ -1,4 +1,3 @@
-'use server'
 
 import Dashboard from '@/app/ui/cuenta/dashboard';
 import { redirect } from 'next/navigation';

--- a/app/entrenadores/[id]/page.tsx
+++ b/app/entrenadores/[id]/page.tsx
@@ -1,4 +1,3 @@
-'use server';
 
 import Info from "@/app/ui/entrenadores/info";
 import { getTrainerById } from "@/service/trainers";

--- a/app/entrenadores/page.tsx
+++ b/app/entrenadores/page.tsx
@@ -1,4 +1,3 @@
-'use server'
 
 import Search from '@/app/ui/entrenadores/search';
 import FilterGrid from '@/app/ui/entrenadores/filters/filter_grid';

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,3 @@
-"use server";
 
 import { Suspense } from "react";
 import LoginForm from "@/app/ui/forms/login_form";

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,4 +1,3 @@
-'use server'
 
 import SignupForm from "@/app/ui/signup/signup_form";
 

--- a/app/soy-entrenador/page.tsx
+++ b/app/soy-entrenador/page.tsx
@@ -1,4 +1,3 @@
-'use server'
 
 import UpdateUserForm from '../ui/soy-entrenador/update_user_form';
 import { redirect } from 'next/navigation';


### PR DESCRIPTION
## Summary

Removes the `'use server'` directive from 6 page files:
- `app/cuenta/page.tsx`
- `app/entrenadores/page.tsx`
- `app/entrenadores/[id]/page.tsx`
- `app/signup/page.tsx`
- `app/login/page.tsx`
- `app/soy-entrenador/page.tsx`

`'use server'` marks a module as Server Actions (callable as RPC from the client). It is not the directive that makes something a server component — RSCs are server-by-default in Next.js and need no directive. The incorrect directive exposes each export as a potential RPC endpoint.

## Test plan

- [ ] All 6 pages still render correctly
- [ ] No TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)