### PR TITLE
feat(cuenta): change password from the account profile

### DIFF
--- a/app/cuenta/page.tsx
+++ b/app/cuenta/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { auth } from '@/service/auth/auth';
 import { getTrainerByUserId } from '@/service/trainers';
+import { userHasPasswordAccount } from '@/service/users';
 
 export default async function Page() {
   const session = await auth.api.getSession({ headers: await headers() });
@@ -15,6 +16,8 @@ export default async function Page() {
   const trainerData = await getTrainerByUserId(session.user.id).catch(() => null);
   const trainer = trainerData ? { ...trainerData, email: session.user.email } : null;
 
+  const hasPassword = await userHasPasswordAccount(session.user.id);
+
   return (
     <div className='animate-fade-in'>
       <div className='mb-8'>
@@ -25,7 +28,7 @@ export default async function Page() {
           Gestioná tu información personal y perfil de entrenador
         </p>
       </div>
-      <Dashboard user={session.user} trainer={trainer}/>
+      <Dashboard user={session.user} trainer={trainer} hasPassword={hasPassword}/>
     </div>
   );
 };

--- a/app/cuenta/page.tsx
+++ b/app/cuenta/page.tsx
@@ -16,8 +16,7 @@ export default async function Page() {
   const trainerData = await getTrainerByUserId(session.user.id).catch(() => null);
   const trainer = trainerData ? { ...trainerData, email: session.user.email } : null;
 
-  const hasPassword = await userHasPasswordAccount(session.user.id);
-
+  const hasPassword = await userHasPasswordAccount(session.user.id).catch(() => false);
   return (
     <div className='animate-fade-in'>
       <div className='mb-8'>

--- a/app/ui/cuenta/change_password.tsx
+++ b/app/ui/cuenta/change_password.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { LockClosedIcon } from '@heroicons/react/24/outline'
+import { useState, useEffect } from 'react'
+import Input from '@/app/ui/form/input'
+import Button from '@/app/ui/form/button'
+import Message from '@/app/ui/form/message'
+import PasswordStrengthIndicator from '@/app/ui/signup/password_strength_indicator'
+import { authClient } from '@/service/auth/auth-client'
+
+export default function ChangePassword({ hasPassword }: {
+  hasPassword: boolean
+}) {
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [revokeOtherSessions, setRevokeOtherSessions] = useState(false)
+  const [passwordMatch, setPasswordMatch] = useState(true)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (confirmPassword) {
+      setPasswordMatch(password === confirmPassword)
+    } else {
+      setPasswordMatch(true)
+    }
+  }, [password, confirmPassword])
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+
+    if (password !== confirmPassword) {
+      setError('Las contraseñas no coinciden')
+      return
+    }
+
+    if (password.length < 8) {
+      setError('La contraseña debe tener al menos 8 caracteres')
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    setSuccess(null)
+
+    try {
+      const { error: changeError } = await authClient.changePassword({
+        currentPassword,
+        newPassword: password,
+        revokeOtherSessions,
+      })
+
+      if (changeError) {
+        if (changeError.status === 429) {
+          setError('Demasiados intentos. Intentá de nuevo más tarde.')
+        } else if (changeError.code === 'INVALID_PASSWORD') {
+          setError('La contraseña actual es incorrecta.')
+        } else {
+          setError(changeError.message || 'Ocurrió un error. Por favor, intentá de nuevo.')
+        }
+        return
+      }
+
+      setSuccess('Tu contraseña fue actualizada correctamente.')
+      setCurrentPassword('')
+      setPassword('')
+      setConfirmPassword('')
+    } catch (error) {
+      setError('Ocurrió un error. Por favor, intentá de nuevo.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!hasPassword) {
+    return (
+      <div className='pt-6 border-t border-gray-200'>
+        <h2 className='text-2xl font-bold text-gray-900 mb-2'>Contraseña</h2>
+        <p className='text-gray-600 text-sm'>
+          Iniciaste sesión con Google, así que no tenés una contraseña para cambiar.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className='pt-6 border-t border-gray-200 space-y-6'>
+      <div>
+        <h2 className='text-2xl font-bold text-gray-900 mb-2'>Cambiar contraseña</h2>
+        <p className='text-gray-600'>
+          Actualizá la contraseña de tu cuenta
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className='space-y-4'>
+        <Input
+          id='currentPassword'
+          type='password'
+          name='currentPassword'
+          placeholder='Contraseña actual'
+          required={true}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          value={currentPassword}
+        >
+          <LockClosedIcon className='h-5 w-5' />
+        </Input>
+
+        <div>
+          <Input
+            id='newPassword'
+            type='password'
+            name='newPassword'
+            placeholder='Nueva contraseña'
+            required={true}
+            onChange={(e) => setPassword(e.target.value)}
+            value={password}
+          >
+            <LockClosedIcon className='h-5 w-5' />
+          </Input>
+          {password && (
+            <div className='mt-2'>
+              <PasswordStrengthIndicator password={password} />
+            </div>
+          )}
+        </div>
+
+        <Input
+          id='confirmPassword'
+          type='password'
+          name='confirmPassword'
+          placeholder='Confirmar nueva contraseña'
+          required={true}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          value={confirmPassword}
+          error={!passwordMatch ? 'Las contraseñas no coinciden' : null}
+        >
+          <LockClosedIcon className='h-5 w-5' />
+        </Input>
+
+        <label className='flex items-center gap-2 text-sm text-gray-600'>
+          <input
+            type='checkbox'
+            checked={revokeOtherSessions}
+            onChange={(e) => setRevokeOtherSessions(e.target.checked)}
+            className='h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500'
+          />
+          Cerrar sesión en otros dispositivos
+        </label>
+
+        <Button
+          text={isLoading ? 'Guardando...' : 'Cambiar contraseña'}
+          disabled={isLoading || !passwordMatch || password.length < 8}
+        />
+
+        {error && <Message type='error' msg={error} />}
+        {success && <Message type='success' msg={success} />}
+      </form>
+    </div>
+  )
+}

--- a/app/ui/cuenta/dashboard.tsx
+++ b/app/ui/cuenta/dashboard.tsx
@@ -4,13 +4,15 @@ import { useState } from 'react'
 import type { TrainerWithEmail } from '@/types/trainers'
 import type { SessionUser } from '@/types/users'
 import AccountInfo from '@/app/ui/cuenta/account_info'
+import ChangePassword from '@/app/ui/cuenta/change_password'
 import VerticalNavbar from '@/app/ui/cuenta/vertical_navbar'
 import TrainerProfile from '@/app/ui/cuenta/trainer_profile'
 import Students from '@/app/ui/cuenta/students'
 
-export default function Dashboard({ user, trainer }: {
+export default function Dashboard({ user, trainer, hasPassword }: {
   user: SessionUser,
-  trainer: TrainerWithEmail | null
+  trainer: TrainerWithEmail | null,
+  hasPassword: boolean
 }) {
   const [selected, setSelected] = useState(0)
 
@@ -29,7 +31,12 @@ export default function Dashboard({ user, trainer }: {
       />
       <div className='flex-1 min-w-0'>
         <div className='bg-white rounded-2xl shadow-large border border-gray-100 p-6 md:p-8'>
-          {selected === 0 && <AccountInfo user={user}/>}
+          {selected === 0 && (
+            <div className='space-y-8'>
+              <AccountInfo user={user}/>
+              <ChangePassword hasPassword={hasPassword}/>
+            </div>
+          )}
           {trainer && selected === 1 && <TrainerProfile trainer={trainer}/>}
           {trainer && selected === 2 && <Students />}
         </div>

--- a/service/auth/auth.ts
+++ b/service/auth/auth.ts
@@ -115,10 +115,7 @@ export const auth = betterAuth({
         validateName(ctx.body?.name, "El nombre");
         validateName(ctx.body?.surname, "El apellido");
       }
-      if (ctx.path === "/reset-password") {
-        validatePassword(ctx.body?.newPassword);
-      }
-      if (ctx.path === "/change-password") {
+      if (ctx.path === "/reset-password" || ctx.path === "/change-password") {
         validatePassword(ctx.body?.newPassword);
       }
     }),

--- a/service/auth/auth.ts
+++ b/service/auth/auth.ts
@@ -118,6 +118,9 @@ export const auth = betterAuth({
       if (ctx.path === "/reset-password") {
         validatePassword(ctx.body?.newPassword);
       }
+      if (ctx.path === "/change-password") {
+        validatePassword(ctx.body?.newPassword);
+      }
     }),
   },
   plugins: [nextCookies()],

--- a/service/users.ts
+++ b/service/users.ts
@@ -1,6 +1,6 @@
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@/db/index";
-import { users } from "@/db/schema";
+import { users, accounts } from "@/db/schema";
 import type { UpdateUser, SelectUser } from "@/types/users";
 import { UserNotFoundError } from "@/service/errors";
 
@@ -25,4 +25,18 @@ export async function updateUserProfile(
   if (!user) throw new UserNotFoundError();
 
   return user;
+}
+
+// Google-only users have no password account, so the change-password form is
+// hidden for them.
+export async function userHasPasswordAccount(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: accounts.id })
+    .from(accounts)
+    .where(
+      and(eq(accounts.userId, userId), eq(accounts.providerId, "credential")),
+    )
+    .limit(1);
+
+  return !!row;
 }


### PR DESCRIPTION
## Summary

Adds a **change-password form to the account profile** (the "Mi cuenta" tab), for users who haven't forgotten their password. Uses Better Auth's `authClient.changePassword`.

## Behavior
- Fields: current password, new password, confirm. New password runs through the same `PasswordStrengthIndicator` and policy as signup/reset.
- Optional **"Cerrar sesión en otros dispositivos"** checkbox (`revokeOtherSessions`), unchecked by default.
- **Google-only users** (no `credential` account) see a note instead of the form — they have no password to change.
- Error handling mirrors the reset form (429 → too many attempts, `INVALID_PASSWORD` → wrong current password, generic fallback).

## Implementation
- `userHasPasswordAccount(userId)` in `service/users.ts` checks the `accounts` table for a `credential` provider; surfaced to the UI as `hasPassword`.
- New `app/ui/cuenta/change_password.tsx`, rendered under `AccountInfo` in the "Mi cuenta" panel.
- `auth.ts` `before` hook now applies the full password policy to `/change-password` (not just min length).
- **No** schema, migration, or new API route — handled by Better Auth's catch-all.
