### PR TITLE
fix(trainer): persist profile visibility as boolean

### DIFF
--- a/src/service/trainers.ts
+++ b/src/service/trainers.ts
@@ -194,7 +194,7 @@ export async function updateTrainerVisibility(
   if (!trainer) throw new TrainerNotFoundError();
 
   const updatedTrainer = await updateTrainer(trainer.id, {
-    is_visible: isVisible ? true : null,
+    is_visible: isVisible,
   });
   if (!updatedTrainer) throw new TrainerNotFoundError();
   return updatedTrainer;


### PR DESCRIPTION
## Problem

When a trainer hides their profile, hiding works correctly. But when they return to their profile, the visibility toggle always shows as **visible (true)** by default, making it impossible to reflect/restore the actual state.

## Cause

`updateTrainerVisibility` stored `is_visible` as `null` when hiding (`isVisible ? true : null`). The component initializes its state with `trainer.is_visible ?? true`, so `null ?? true` always evaluated to `true`.

## Fix

Store the boolean directly (`is_visible: isVisible`) in `src/service/trainers.ts`, so `false` is persisted correctly.

## Note

Records already set to `NULL` before this fix will still show the toggle as active until toggled again (or normalized with `UPDATE trainers SET is_visible = false WHERE is_visible IS NULL`).