### PR TITLE
feat(mailer): notify admins when a new trainer registers

### DIFF
--- a/src/service/mailer.ts
+++ b/src/service/mailer.ts
@@ -2,10 +2,12 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { Resend } from "resend";
 import { ServerError } from "@/service/errors";
+import { listAdmins } from "@/service/users";
 
 export interface Mailer {
   sendVerification(email: string, name: string, url: string): Promise<void>;
   sendPasswordReset(email: string, name: string, url: string): Promise<void>;
+  sendNewTrainer(): Promise<void>;
 }
 
 function getEnv(key: string): string {
@@ -37,6 +39,21 @@ class ResendMailer implements Mailer {
 
   async sendPasswordReset(email: string, name: string, url: string): Promise<void> {
     await this.send(email, "Resetear tu contraseña - BuscarEntrenador.com", "reset-password", { name, url });
+  }
+
+  async sendNewTrainer(): Promise<void> {
+    const admins = await listAdmins();
+    const url = `${getEnv("NEXT_PUBLIC_APP_URL")}/admin`;
+    await Promise.all(
+      admins.map((admin) =>
+        this.send(
+          admin.email,
+          "Nuevo entrenador registrado - BuscarEntrenador.com",
+          "new-trainer",
+          { name: admin.name, url },
+        ),
+      ),
+    );
   }
 
   private async send(

--- a/src/service/templates/new-trainer.html
+++ b/src/service/templates/new-trainer.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nuevo entrenador registrado</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+  <div style="background-color: #f4f4f4; padding: 20px; border-radius: 10px;">
+    <h1 style="color: #4f46e5; margin-bottom: 20px;">Nuevo entrenador registrado</h1>
+
+    <p>Hola {{name}},</p>
+
+    <p>Un nuevo entrenador se registró en BuscarEntrenador.com y está pendiente de revisión.</p>
+
+    <div style="text-align: center; margin: 30px 0;">
+      <a href="{{url}}"
+         style="background-color: #4f46e5; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;">
+        Revisar en el panel
+      </a>
+    </div>
+
+    <p>Si el botón no funciona, copiá y pegá el siguiente enlace en tu navegador:</p>
+    <p style="word-break: break-all; color: #4f46e5;">{{url}}</p>
+
+    <hr style="border: none; border-top: 1px solid #ddd; margin: 30px 0;">
+
+    <p style="color: #999; font-size: 12px; text-align: center;">
+      BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales
+    </p>
+  </div>
+</body>
+</html>

--- a/src/service/templates/new-trainer.txt
+++ b/src/service/templates/new-trainer.txt
@@ -1,0 +1,8 @@
+Hola {{name}},
+
+Un nuevo entrenador se registró en BuscarEntrenador.com y está pendiente de revisión.
+
+Revisalo en el panel de administración:
+{{url}}
+
+BuscarEntrenador.com - Tu plataforma para encontrar entrenadores personales

--- a/src/service/trainers.ts
+++ b/src/service/trainers.ts
@@ -8,6 +8,7 @@ import type {
   TrainerWithEmail,
 } from "@/types/trainers";
 import { TrainerNotFoundError } from "@/service/errors";
+import { mailer } from "@/service/mailer";
 
 function publicTrainerSelect() {
   return {
@@ -168,12 +169,13 @@ export async function createOrUpdateTrainer(
 ): Promise<{ id: number }> {
   let trainerId: number;
   const existingTrainer = await getTrainerByUserId(userId);
+  const created = !existingTrainer;
   if (existingTrainer) {
     trainerId = existingTrainer.id;
   } else {
-    const created = await createTrainer(userId);
-    if (!created) throw new TrainerNotFoundError();
-    trainerId = created.id;
+    const newTrainer = await createTrainer(userId);
+    if (!newTrainer) throw new TrainerNotFoundError();
+    trainerId = newTrainer.id;
   }
 
   // A rejected trainer who edits and resubmits goes back into the queue, as if
@@ -183,6 +185,17 @@ export async function createOrUpdateTrainer(
 
   const updatedTrainer = await updateTrainer(trainerId, updates);
   if (!updatedTrainer) throw new TrainerNotFoundError();
+
+  // Notify admins of a newly registered trainer. Non-critical: a mail failure
+  // must not fail the trainer creation.
+  if (created) {
+    try {
+      await mailer.sendNewTrainer();
+    } catch (error) {
+      console.error("Failed to send new trainer notification:", error);
+    }
+  }
+
   return updatedTrainer;
 }
 

--- a/src/service/trainers.ts
+++ b/src/service/trainers.ts
@@ -186,8 +186,6 @@ export async function createOrUpdateTrainer(
   const updatedTrainer = await updateTrainer(trainerId, updates);
   if (!updatedTrainer) throw new TrainerNotFoundError();
 
-  // Notify admins of a newly registered trainer. Non-critical: a mail failure
-  // must not fail the trainer creation.
   if (created) {
     try {
       await mailer.sendNewTrainer();

--- a/src/service/users.ts
+++ b/src/service/users.ts
@@ -27,6 +27,15 @@ export async function updateUserProfile(
   return user;
 }
 
+export async function listAdmins(): Promise<
+  Pick<SelectUser, "email" | "name">[]
+> {
+  return db
+    .select({ email: users.email, name: users.name })
+    .from(users)
+    .where(eq(users.role, "admin"));
+}
+
 // Google-only users have no password account, so the change-password form is
 // hidden for them.
 export async function userHasPasswordAccount(userId: string): Promise<boolean> {


### PR DESCRIPTION
- add listAdmins() query in service/users.ts
- add mailer.sendNewTrainer() that emails all admins via Resend
- call it from createOrUpdateTrainer when a trainer is first created
- add new-trainer email templates (html/txt)